### PR TITLE
update base to 440.82-2 and beta to 440.66.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NVIDIA_VERSION = 440.82
-NVIDIA_VERSION_DEB = 1
+NVIDIA_VERSION_DEB = 2
 
-NVIDIA_BETA_VERSION = 440.66.12
+NVIDIA_BETA_VERSION = 440.66.15
 NVIDIA_BETA_PKG = nvidia-graphics-drivers-$(NVIDIA_BETA_VERSION)
 NVIDIA_BETA_TAR = nvidia-graphics-drivers_$(NVIDIA_BETA_VERSION)
 NVIDIA_BETA_URL = https://developer.nvidia.com/vulkan-beta-$(subst .,,$(NVIDIA_BETA_VERSION))-linux


### PR DESCRIPTION
thanks a lot for making this, just successfully built and installed 440.66.15 with these changes.
had to patch it with https://gitlab.com/snippets/1945940 to get the kernel modules built for linux 5.6 if the information is of any use to you.